### PR TITLE
feat: Add propagation scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved build tools from Babel to tsup/esbuild
 
+### Added
+
+- Introduced `PropagationScope` component for scoping propagations in the component tree, by [@OEvgeny](https://github.com/OEvgeny) in PR [#15](https://github.com/compulim/use-propagate/pull/15)
+  - Updated `useListen` and `usePropagate` hooks to use `PropagateContext`, by [@OEvgeny](https://github.com/OEvgeny) in PR [#15](https://github.com/compulim/use-propagate/pull/15)
+
 ### Changed
 
 - Streamlined code, by [@compulim](https://github.com/compulim) in PR [#5](https://github.com/compulim/use-propagate/pull/5)

--- a/README.md
+++ b/README.md
@@ -53,12 +53,70 @@ render(
 );
 ```
 
+### PropagationScope
+
+The `PropagationScope` component allows you to create isolated scopes for propagation. This is useful when you want to limit the scope of propagation to a specific part of your component tree.
+
+Here's an example of how to use `PropagationScope`:
+
+```tsx
+import { createPropagation } from 'use-propagate';
+
+const { useListen, usePropagate, PropagationScope } = createPropagation<string>();
+
+const ParentComponent = () => {
+  return (
+    <div>
+      <PropagationScope>
+        <ChildComponent1 />
+        <ChildComponent2 />
+      </PropagationScope>
+      <ChildComponent3 />
+    </div>
+  );
+};
+
+const ChildComponent1 = () => {
+  const propagate = usePropagate();
+  
+  return <button onClick={() => propagate('Hello')}>Say Hello</button>;
+};
+
+const ChildComponent2 = () => {
+  useListen((message) => {
+    console.log('ChildComponent2 received:', message);
+  });
+
+  return <div>Child 2</div>;
+};
+
+const ChildComponent3 = () => {
+  useListen((message) => {
+    console.log('ChildComponent3 received:', message);
+  });
+
+  return <div>Child 3</div>;
+};
+```
+
+In this example:
+
+- `ChildComponent1` and `ChildComponent2` are wrapped in a `PropagationScope`.
+- When the button in `ChildComponent1` is clicked, it will propagate the message "Hello".
+- `ChildComponent2` will receive this message and log it.
+- `ChildComponent3`, which is outside the `PropagationScope`, will not receive the message.
+
+Using `PropagationScope` allows you to create multiple isolated propagation contexts within your application. This can be particularly useful in larger applications where you want to avoid unintended propagation between different parts of your component tree.
+
+Note that `useListen` and `usePropagate` will use the nearest `PropagationScope` in the component tree. If there's no `PropagationScope` ancestor, they will use a default global scope.
+
 ## API
 
 ```ts
-export function createPropagation<T>(): {
+export function createPropagation<T>(options?: { allowPropagateDuringRender?: boolean }): {
+  PropagationScope: React.ComponentType<{ children: React.ReactNode }>;
   useListen: (callback: (value: T) => void) => void;
-  usePropagate: (value: T) => void;
+  usePropagate: () => (value: T) => void;
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Note that `useListen` and `usePropagate` will use the nearest `PropagationScope`
 
 ```ts
 export function createPropagation<T>(options?: { allowPropagateDuringRender?: boolean }): {
-  PropagationScope: React.ComponentType<{ children: React.ReactNode }>;
+  PropagationScope: React.ComponentType<{ children?: React.ReactNode | undefined }>;
   useListen: (callback: (value: T) => void) => void;
   usePropagate: () => (value: T) => void;
 };

--- a/packages/use-propagate/src/index.ts
+++ b/packages/use-propagate/src/index.ts
@@ -1,3 +1,3 @@
-import createPropagation from './createPropagation';
+import createPropagation from './private/createPropagation';
 
 export { createPropagation };

--- a/packages/use-propagate/src/private/createPropagateContextValue.tsx
+++ b/packages/use-propagate/src/private/createPropagateContextValue.tsx
@@ -1,0 +1,23 @@
+import { Listener } from './createPropagation';
+
+export type PropagateContext<T> = Readonly<{
+  addListener(listener: Listener<T>): void;
+  removeListener(listener: Listener<T>): void;
+  runListeners(value: T): void;
+}>;
+
+export function createPropagateContextValue<T>(): PropagateContext<T> {
+  type Fn = Listener<T>;
+  const listeners = new Set<Fn>();
+  return {
+    addListener(listener: Fn) {
+      listeners.add(listener);
+    },
+    removeListener(listener: Fn) {
+      listeners.delete(listener);
+    },
+    runListeners(value: T) {
+      listeners.forEach(listener => listener(value));
+    }
+  };
+}

--- a/packages/use-propagate/src/private/createPropagateContextValue.tsx
+++ b/packages/use-propagate/src/private/createPropagateContextValue.tsx
@@ -1,12 +1,12 @@
 import { Listener } from './createPropagation';
 
-export type PropagateContext<T> = Readonly<{
+export type PropagationContext<T> = Readonly<{
   addListener(listener: Listener<T>): void;
   removeListener(listener: Listener<T>): void;
   runListeners(value: T): void;
 }>;
 
-export function createPropagateContextValue<T>(): PropagateContext<T> {
+export function createPropagationContextValue<T>(): PropagationContext<T> {
   type Fn = Listener<T>;
   const listeners = new Set<Fn>();
   return {

--- a/packages/use-propagate/src/private/createPropagateContextValue.tsx
+++ b/packages/use-propagate/src/private/createPropagateContextValue.tsx
@@ -1,4 +1,4 @@
-import { Listener } from './createPropagation';
+export type Listener<T> = (value: T) => void;
 
 export type PropagationContext<T> = Readonly<{
   addListener(listener: Listener<T>): void;
@@ -6,7 +6,7 @@ export type PropagationContext<T> = Readonly<{
   runListeners(value: T): void;
 }>;
 
-export function createPropagationContextValue<T>(): PropagationContext<T> {
+export default function createPropagationContextValue<T>(): PropagationContext<T> {
   type Fn = Listener<T>;
   const listeners = new Set<Fn>();
   return {

--- a/packages/use-propagate/src/private/createPropagation.spec.tsx
+++ b/packages/use-propagate/src/private/createPropagation.spec.tsx
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
 import { render, type RenderResult } from '@testing-library/react';
-import React, { useState, Fragment, useCallback, type ComponentType } from 'react';
+import React, { Fragment, useCallback, useState, type ComponentType } from 'react';
 
 import createPropagation from './createPropagation';
 

--- a/packages/use-propagate/src/private/createPropagation.tsx
+++ b/packages/use-propagate/src/private/createPropagation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createContext, memo, useContext, useEffect, useLayoutEffect, useMemo, type ReactNode } from 'react';
 import { useRefFrom } from 'use-ref-from';
-import createPropagationContextValue, { Listener, PropagationContext } from './createPropagateContextValue';
+import createPropagationContextValue, { type Listener, type PropagationContext } from './createPropagateContextValue';
 
 type Init = {
   /**

--- a/packages/use-propagate/src/private/createPropagation.tsx
+++ b/packages/use-propagate/src/private/createPropagation.tsx
@@ -23,7 +23,7 @@ export default function createPropagation<T>(init: Init = {}) {
 
   let rendering: boolean = false;
 
-  function PropagationScope({ children }: Readonly<{ children: ReactNode }>) {
+  function PropagationScope({ children }: Readonly<{ children?: ReactNode | undefined }>) {
     const value = useMemo<PropagationContext<T>>(createPropagationContextValue, []);
     return <context.Provider value={value}>{children}</context.Provider>;
   }

--- a/packages/use-propagate/src/private/createPropagation.tsx
+++ b/packages/use-propagate/src/private/createPropagation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createContext, memo, useContext, useEffect, useLayoutEffect, useMemo, type ReactNode } from 'react';
 import { useRefFrom } from 'use-ref-from';
-import { PropagateContext, createPropagateContextValue } from './createPropagateContextValue';
+import { createPropagationContextValue, PropagationContext } from './createPropagateContextValue';
 
 export type Listener<T> = (value: T) => void;
 
@@ -19,12 +19,12 @@ export default function createPropagation<T>(init: Init = {}) {
   type Fn = Listener<T>;
 
   const { allowPropagateDuringRender } = init;
-  const context = createContext<PropagateContext<T>>(createPropagateContextValue());
+  const context = createContext<PropagationContext<T>>(createPropagationContextValue());
 
   let rendering: boolean = false;
 
   function PropagationScope({ children }: Readonly<{ children: ReactNode }>) {
-    const value = useMemo<PropagateContext<T>>(createPropagateContextValue, []);
+    const value = useMemo<PropagationContext<T>>(createPropagationContextValue, []);
     return <context.Provider value={value}>{children}</context.Provider>;
   }
 

--- a/packages/use-propagate/src/private/createPropagation.tsx
+++ b/packages/use-propagate/src/private/createPropagation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createContext, memo, type ReactNode, useContext, useEffect, useLayoutEffect, useMemo } from 'react';
+import { createContext, memo, useContext, useEffect, useLayoutEffect, useMemo, type ReactNode } from 'react';
 import { useRefFrom } from 'use-ref-from';
 import { PropagateContext, createPropagateContextValue } from './createPropagateContextValue';
 

--- a/packages/use-propagate/src/private/createPropagation.tsx
+++ b/packages/use-propagate/src/private/createPropagation.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { createContext, memo, useContext, useEffect, useLayoutEffect, useMemo, type ReactNode } from 'react';
 import { useRefFrom } from 'use-ref-from';
-import { createPropagationContextValue, PropagationContext } from './createPropagateContextValue';
-
-export type Listener<T> = (value: T) => void;
+import createPropagationContextValue, { Listener, PropagationContext } from './createPropagateContextValue';
 
 type Init = {
   /**


### PR DESCRIPTION
## Changelog

### Added

- Introduced `PropagationScope` component for scoping propagations in the component tree, by [@OEvgeny](https://github.com/OEvgeny) in PR [#15](https://github.com/compulim/use-propagate/pull/15)
  - Updated `useListen` and `usePropagate` hooks to use `PropagateContext`, by [@OEvgeny](https://github.com/OEvgeny) in PR [#15](https://github.com/compulim/use-propagate/pull/15)

## Specific changes

- Implemented `PropagationScope` component to create isolated contexts for propagation
- Modified `useListen` and `usePropagate` hooks to register listeners within the nearest `PropagationScope` context
- Added tests for `PropagationScope` functionality
